### PR TITLE
Show congrats if merge

### DIFF
--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
     Congrats:
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         steps:
             - name: Congrats


### PR DESCRIPTION
Now we only post the congrats message if a PR is merged. This prevents threads like this, that trigger on PRs closing: https://github.com/hackclub/OnBoard/pull/41#issuecomment-1565818689