### PR TITLE
Only run congrats on submissions being merged

### DIFF
--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     Congrats:
-        if: github.event.pull_request.merged == true
+        if: github.event.pull_request.merged == true  && contains(github.event.pull_request.labels.*.name, 'Submission')
         runs-on: ubuntu-latest
         steps:
             - name: Congrats


### PR DESCRIPTION
This fixes a bug where the congrats ("you get a grant") workflow runs for regular fixes to the repo like updating the README.
