### PR TITLE
Add PCBGogo to vendors

### DIFF
--- a/VENDORS.md
+++ b/VENDORS.md
@@ -4,6 +4,7 @@ This is the list of approved vendors that the HCB grant cards can be used on. To
 
 - [JLCPCB](https://jlcpcb.com/): The default vendor.
 <!-- add more under this line to suggest a new vendor after reading the directions -->
+- [PCBgogo](https://www.pcbgogo.com): Cheaper shipping for UK via Hong Kong post + $50 coupon for first time users.
 
 ## Adding to the list
 


### PR DESCRIPTION
## Submission Checklist:

![Screenshot 2023-06-02 at 17 49 19](https://github.com/hackclub/OnBoard/assets/80623330/051d91b2-8b90-434f-8bb0-3f9bd6b38d04)

In my experience, they are generally cheaper for first time buyers and even provide a $50 discount If you sign up for an account. Postage is cheaper than PCBWay but please note the final price is dependent on the customs that need to be paid for your country so it may actually be more expensive than shown initially. So far JLCPCB is the only vendor which includes tax/customs in the initial payment. Most other vendors do not.