### PR TITLE
Add PCBWay to vendors.md

### DIFF
--- a/VENDORS.md
+++ b/VENDORS.md
@@ -4,7 +4,7 @@ This is the list of approved vendors that the HCB grant cards can be used on. To
 
 - [JLCPCB](https://jlcpcb.com/): The default vendor.
 <!-- add more under this line to suggest a new vendor after reading the directions -->
- - [PCBWAY](https://www.pcbway.com)
+- [PCBWAY](https://www.pcbway.com)
 
 ## Adding to the list
 


### PR DESCRIPTION
Hi,
As some of us have explained earlier, PCBWAY is a little more efficient to ship to APACers. It also offers dual layer PCB assembly for a lower rate. Thereby, this pr :D 