### PR TITLE
Mark Stale Pull Requests

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,34 @@
+name: Cleanup Pull Requests
+on:
+  push:
+      branches:
+          - main
+      
+jobs:
+    mark-tickets:
+        runs-on: ubuntu-latest
+        permissions: 
+          pull-requests: write
+          issues: write
+        steps: 
+          - name: Close Stale Issues
+            uses: actions/stale@v9.0.0
+            with:
+              stale-pr-message: >
+                  Hi, please feel free to ask for help if you need any here or [#electronics on Slack](https://hackclub.com/slack/?event=onboard). This pull request is being marked as "Stalled" for the meantime and will be closed in 3 days of no activity.
+              close-pr-message: >
+                  This pull request has been without activity for some time and therefore has been closed, feel free to create a new one when you're ready.
+              # The number of days old an issue or a pull request can be before marking it stale. Set to -1 to never mark issues or pull requests as stale automatically.
+              days-before-stale: 7
+              # The number of days to wait to close an issue or a pull request after it being marked stale. Set to -1 to never close stale issues or pull requests.
+              days-before-close: 14
+              # The number of days to wait to close an issue after it being marked stale. Set to -1 to never close stale issues. Override "days-before-close" option regarding only the issues.
+              days-before-issue-close: -1
+              # The label to apply when an issue is stale.
+              stale-issue-label: "Stalled"
+              # The labels that mean an issue is exempt from being marked stale. Separate multiple labels with commas (eg. "label1,label2").
+              exempt-issue-labels: "Dev"
+              # The label to apply when a pull request is stale.
+              stale-pr-label: "Stalled"
+              # Only pull requests with at least one of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels. Override "any-of-labels" option regarding only the pull requests.
+              any-of-pr-labels: Submission

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,9 +15,9 @@ jobs:
             uses: actions/stale@v9.0.0
             with:
               stale-pr-message: >
-                  Hi, please feel free to ask for help if you need any here or [#electronics on Slack](https://hackclub.com/slack/?event=onboard). This pull request is being marked as "Stalled" for the meantime and will be closed in 3 days of no activity.
+                Hi, if you need any assistance, please don't hesitate to ask here or in #electronics on Slack. This pull request is being marked as 'Stalled' for now and will be closed in 3 days if there is no activity.
               close-pr-message: >
-                  This pull request has been without activity for some time and therefore has been closed, feel free to create a new one when you're ready.
+                  This pull request has been inactive for some time and has therefore been closed. Feel free to create a new one when you're ready.
               # The number of days old an issue or a pull request can be before marking it stale. Set to -1 to never mark issues or pull requests as stale automatically.
               days-before-stale: 7
               # The number of days to wait to close an issue or a pull request after it being marked stale. Set to -1 to never close stale issues or pull requests.


### PR DESCRIPTION
OnBoard's PCB submissions can pile up fast, and sometimes people get carried away and haven't responded in some time. To manage all the pull requests, I created a workflow to comment on pull requests which have had 7 days without activity warning them that the pull request may be closed and to ask for help if they need it; this will also mark the pull request with the "Stalled" label. If it has been 14 days total since they opened the pull request, the workflow will close the pull request and send a message saying to open a new one if they're still looking to get their PCB ordered. 

Hopfully this will cut down the number of pull requests and give people a reminder that their pull request is still open.