### PR TITLE
Automation for Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@ Invalid:
 - all:
   - changed-files:
     - any-glob-to-any-file: '*'
-    - all-globs-to-any-files: '!projects*'
+    - all-globs-to-any-file: '!projects*'
 
 
 # Add 'Submission' label to any changes within '/projects' folder or any subfolders

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,19 +4,13 @@ Invalid:
     - any-glob-to-any-file: '*'
     - all-globs-to-any-file: 'projects/**'
 
-
 # Add 'Submission' label to any changes within '/projects' folder or any subfolders
 Submission:
 - changed-files:
-  - any-glob-to-any-file: projects/**
-
+  - any-glob-to-any-file: 'projects/**'
 
 Dev:
 - all:
   - changed-files:
-    - any-glob-to-any-file:
-      - .github/*
-      - community/*
-      - docs/*
-      - meta/*
+    - any-glob-to-any-file: '*'
     - all-globs-to-any-file: '!projects/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,8 @@
 Invalid:
-- changed-files:
-  - any-glob-to-any-file: '*'
-  - all-globs-to-any-files: '!projects*'
+- all:
+  - changed-files:
+    - any-glob-to-any-file: '*'
+    - all-globs-to-any-files: '!projects*'
 
 
 # Add 'Submission' label to any changes within '/projects' folder or any subfolders

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@ Invalid:
 - all:
   - changed-files:
     - any-glob-to-any-file: '*'
-    - all-globs-to-any-file: '!projects*'
+    - all-globs-to-any-file: 'projects/**'
 
 
 # Add 'Submission' label to any changes within '/projects' folder or any subfolders
@@ -12,9 +12,11 @@ Submission:
 
 
 Dev:
-- changed-files:
-  - any-glob-to-any-file:
-    - .github/*
-    - community/*
-    - docs/*
-    - meta/*
+- all:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/*
+      - community/*
+      - docs/*
+      - meta/*
+    - all-globs-to-any-file: '!projects/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,4 +13,4 @@ Dev:
 - all:
   - changed-files:
     - any-glob-to-any-file: '*'
-    - all-globs-to-any-file: '!projects/**'
+    - any-globs-to-any-file: '!projects/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,4 +13,4 @@ Dev:
 - all:
   - changed-files:
     - any-glob-to-any-file: '*'
-    - any-glob-to-any-file: '!projects/**'
+    - all-globs-to-any-file: '!projects/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,19 @@
+Invalid:
+- changed-files:
+  - any-glob-to-any-file: '*'
+
+# Add 'Submission' label to any changes within '/projects' folder or any subfolders
+Submission:
+- changed-files:
+  - any-glob-to-any-file: projects/**
+
+
+Dev:
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/*
+    - community/*
+    - docs/*
+    - meta/*
+
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,4 +13,4 @@ Dev:
 - all:
   - changed-files:
     - any-glob-to-any-file: '*'
-    - any-globs-to-any-file: '!projects/**'
+    - any-glob-to-any-file: '!projects/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,8 @@
 Invalid:
 - changed-files:
   - any-glob-to-any-file: '*'
+  - all-globs-to-any-files: '!projects*'
+
 
 # Add 'Submission' label to any changes within '/projects' folder or any subfolders
 Submission:
@@ -15,5 +17,3 @@ Dev:
     - community/*
     - docs/*
     - meta/*
-
-

--- a/.github/workflows/organize.yml
+++ b/.github/workflows/organize.yml
@@ -1,8 +1,7 @@
 name: Cleanup Pull Requests
-on:
-  push:
-      branches:
-          - main
+on: 
+    pull_request: 
+        types: [ opened, synchronize, reopened, assigned]
       
 jobs:
     stalled-tickets:

--- a/.github/workflows/organize.yml
+++ b/.github/workflows/organize.yml
@@ -5,7 +5,7 @@ on:
           - main
       
 jobs:
-    mark-tickets:
+    stalled-tickets:
         runs-on: ubuntu-latest
         permissions: 
           pull-requests: write
@@ -23,7 +23,7 @@ jobs:
               days-before-issue-stale: 30
               days-before-pr-stale: 7
               # The number of days to wait to close an issue or a pull request after it being marked stale. Set to -1 to never close stale issues or pull requests.
-              days-before-close: 7
+              days-before-close: 3
               # The number of days to wait to close an issue after it being marked stale. Set to -1 to never close stale issues. Override "days-before-close" option regarding only the issues.
               days-before-issue-close: -1
               # The label to apply when an issue is stale.
@@ -36,3 +36,10 @@ jobs:
               # Only pull requests with at least one of these labels are checked if stale. Defaults to `` (disabled) and can be a comma-separated list of labels. Override "any-of-labels" option regarding only the pull requests.
               any-of-pr-labels: "Submission"
               # include-only-assigned: true
+    labeler:
+      permissions:
+        contents: read
+        pull-requests: write
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/labeler@v5

--- a/.github/workflows/organize.yml
+++ b/.github/workflows/organize.yml
@@ -42,5 +42,5 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - uses: actions/labeler@v5
-        with: 
-            sync-labels: true
+        with:
+          sync-labels: true

--- a/.github/workflows/organize.yml
+++ b/.github/workflows/organize.yml
@@ -42,3 +42,5 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - uses: actions/labeler@v5
+        with: 
+            sync-labels: true


### PR DESCRIPTION
Automatically adds labels, either `Submission`, `Dev` or `Invalid`, depending on the directory a person's pull request affects. See below for example scenarios of how it works

> If a user changes anything in the `/projects` directory, the "Submission" label will be automatically added to that person's pull request. 
> 
> If a user changes a directory in the root AND in the `/projects` directory, the `Invalid` label is added.
> 
> If a user changes anything in the root directory but does not touch the `/projects` directory, the `Dev` label is added. 

Might save some time for reviewers and automate a little of the process?