### PR TITLE
Update PR template to include checkbox instructions and OBL checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 ## Submission Checklist:
 
+<!--To check the checkboxes, simply replace the empty space in the brackets with a captial X, like this: [ ] becomes [X]-->
+
 - [ ] I am a current high school, middle school, or home schooled student.
   - [ ] I am 18 or under
   - [ ] I have filled out the [verification form](https://airtable.com/app4Bs8Tjwvk5qcD4/pagxECjJZOgvKVnLd/form)
@@ -15,8 +17,10 @@
   - [ ] If outside the US I've checked that I can afford the customs charges in my country (which isn't covered by the grant)
 
 - [ ] (Optional) This project is from a tutorial[^1].
+- [ ] (Optional) This project is for OnBoard Live[^2].
 - [ ] (Optional) I'm in a FIRST (FRC, FTC, FLL, etc.) team. The number is: ____
 
 [^1]: Projects from a tutorial are 100% fine! We just want to ask so we can count how people are using tutorials.
+[^2]: OnBoard Live is a special version of OnBoard where you can earn more money for designing advanced boards. Check out the #onboard-live channel on [our Slack](https://hackclub.com/slack/?event=onboard)!
 
 <!-- -Submission- -->


### PR DESCRIPTION
OnBoard Live, an extension of OnBoard where you livestream yourself designing a PCB for $5 an hour, needs a system for shipping your project and submitting its associated sessions for review, much like Arcade. @zachlatta thinks this system should be similar to that of OnBoard. This PR is the first step in that direction. It adds an optional checkbox to the PR template to indicate that a PR is for OnBoard Live. This will allow my server to see if a new PR is for OnBoard Live and proceed accordingly. There's also an associated footnote to provide a brief explanation of OnBoard Live. As a bonus, I've also added a comment to the template explaining how to properly check the boxes, since people sometimes get confused by that obscure Markdown syntax. Let me know if any changes are needed!