### PR TITLE
Fix vendors.md link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It should look like this:
 
 **Note:** Your screenshot is **VITAL** since your project cannot be approved without it. You'll include the screenshot in your PR later.
 
-[^5]: Don't know which ones you can use? Check out [`VENDORS.md`](docs/VENDORS.md) for more info!
+[^5]: Don't know which ones you can use? Check out [`VENDORS.md`](./docs/VENDORS.md) for more info!
 [^6]: If outside the US you may be charged customs which aren't covered by the grant! Check beforehand.
 
 ### 4. Fork!


### PR DESCRIPTION

Current path leads to 404 because missing `./`